### PR TITLE
Fixes to security schemes

### DIFF
--- a/examples/secure_request_guard/src/main.rs
+++ b/examples/secure_request_guard/src/main.rs
@@ -1,4 +1,4 @@
-use okapi::openapi3::{Object, Responses, SecurityRequirement, SecurityScheme, SecuritySchemeData};
+use okapi::openapi3::{Object, Responses, SchemeIdentifier, SecurityRequirement, SecurityScheme, SecuritySchemeData};
 use rocket::serde::json::Json;
 use rocket::{
     get,
@@ -58,9 +58,6 @@ impl<'a, 'r> OpenApiFromRequest<'a> for KeyAuthorize {
         // https://swagger.io/docs/specification/authentication/basic-authentication/
         let security_scheme = SecurityScheme {
             description: Some("requires a key to access".into()),
-            // scheme identifier is the keyvalue under which this security_scheme will be filed in
-            // the openapi.json file
-            scheme_identifier: "FixedKeyApiKeyAuth".into(),
             // this will show where and under which name the value will be found in the HTTP header
             // in this case, the header key x-api-key will be searched
             // other alternatives are "query", "cookie" according to the openapi specs.
@@ -73,9 +70,16 @@ impl<'a, 'r> OpenApiFromRequest<'a> for KeyAuthorize {
             extensions: Object::default(),
         };
 
+        // scheme identifier is the keyvalue under which this security_scheme will be filed in
+        // the openapi.json file
+        let scheme_identifier = SchemeIdentifier {
+            scheme_identifier: "FixedKeyApiKeyAuth".into()
+        };
+
         Ok(RequestHeaderInput::Security((
             security_scheme,
             security_req,
+            scheme_identifier,
         )))
     }
 }

--- a/okapi/src/openapi3.rs
+++ b/okapi/src/openapi3.rs
@@ -364,14 +364,16 @@ pub struct SecurityScheme {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "derive_json_schema", derive(JsonSchema))]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[serde(tag = "type")]
 #[allow(clippy::large_enum_variant)]
 pub enum SecuritySchemeData {
+    #[serde(rename = "apiKey")]
     ApiKey {
         name: String,
         #[serde(rename = "in")]
         location: String,
     },
+    #[serde(rename = "http", rename_all = "camelCase")]
     Http {
         scheme: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -381,6 +383,7 @@ pub enum SecuritySchemeData {
     OAuth2 {
         flows: OAuthFlows,
     },
+    #[serde(rename = "openIdConnect", rename_all = "camelCase")]
     OpenIdConnect {
         open_id_connect_url: String,
     },

--- a/okapi/src/openapi3.rs
+++ b/okapi/src/openapi3.rs
@@ -352,14 +352,21 @@ pub struct Header {
 #[cfg_attr(feature = "derive_json_schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct SecurityScheme {
-    // unique name for the security scheme
-    pub scheme_identifier: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(flatten)]
     pub data: SecuritySchemeData,
     #[serde(flatten)]
     pub extensions: Object,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "derive_json_schema", derive(JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct SchemeIdentifier {
+    #[serde(default)]
+    /// Unique name for the security scheme.
+    pub scheme_identifier: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/rocket-okapi-codegen/src/openapi_attr/mod.rs
+++ b/rocket-okapi-codegen/src/openapi_attr/mod.rs
@@ -208,9 +208,9 @@ fn create_route_operation_fn(
                     }
                     RequestHeaderInput::Security(s) => {
                         // Make sure to add the security scheme listing
-                        security_schemes.insert(s.0.scheme_identifier.clone(), Vec::new());
+                        security_schemes.insert(s.2.scheme_identifier.clone(), Vec::new());
                         // Add the scheme to components definition of openapi
-                        gen.add_security_scheme(s.0.scheme_identifier.clone(), s.0.clone());
+                        gen.add_security_scheme(s.2.scheme_identifier.clone(), s.0.clone());
                     }
                     _ => {
                     }

--- a/rocket-okapi/src/request/mod.rs
+++ b/rocket-okapi/src/request/mod.rs
@@ -7,7 +7,7 @@ mod from_request_impls;
 use super::gen::OpenApiGenerator;
 use super::Result;
 extern crate okapi;
-use okapi::openapi3::{Parameter, RequestBody, SecurityRequirement, SecurityScheme};
+use okapi::openapi3::{Parameter, RequestBody, SchemeIdentifier, SecurityRequirement, SecurityScheme};
 
 /// Expose this to the public to be use when manualy implementing a
 /// [Form Guard](https://api.rocket.rs/master/rocket/form/trait.FromForm.html).
@@ -69,7 +69,7 @@ pub enum RequestHeaderInput {
     /// Parameter input to the path, can be used to parse values from the header for example
     Parameter(Parameter),
     /// the request guard implements a security scheme
-    Security((SecurityScheme, SecurityRequirement)),
+    Security((SecurityScheme, SecurityRequirement, SchemeIdentifier)),
 }
 
 impl Into<RequestHeaderInput> for Parameter {


### PR DESCRIPTION
Hi,
thanks for managing this fork.

When I was working on my school project, I noticed that the openapi.json is invalid when using Request guard.
I fixed some capitalization issues and moved scheme_identifier to its own struct so that it isn't as a key under SecurityScheme.

For comparison, here are the [before](https://gist.github.com/iTzBoboCz/50d5951dfcbafcd078b6f3829d7648b8#file-okapi_security_schemes_fix_before-json-L203) and [after](https://gist.github.com/iTzBoboCz/50d5951dfcbafcd078b6f3829d7648b8#file-okapi_security_schemes_fix_after-json-L203).

I tested it using [Swagger Editor](https://editor.swagger.io/) and [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator).
It would be great if you could merge it.
Thanks :)